### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "mustache": "^2.3.2",
     "node-libs-browser": "^2.0.0",
     "normalizr": "^3.0.2",
-    "npm": "^5.8.0",
     "number-to-locale-string": "^1.0.1",
     "password-generator": "^2.0.1",
     "prop-types": "^15.5.7",


### PR DESCRIPTION

Hello crazilazi!

It seems like you have npm as one of your (dev-) dependency in metabasev1.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
